### PR TITLE
Feat add inst name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ pythonpath = ["src", "tests"]
 
 [tool.uv.sources]
 device-spinner = { git = "ssh://git@github.com/AllenNeuralDynamics/device-spinner.git"}
-one-liner = { git = "ssh://git@github.com/AllenNeuralDynamics/one-liner.git" }
+one-liner = { git = "ssh://git@github.com/AllenNeuralDynamics/one-liner.git", branch = "main"}
 runze-control = { git = "https://github.com/AllenNeuralDynamics/runze-control.git", branch = "brain-slosher-fix" }
 pyharp = { git = "https://github.com/AllenNeuralDynamics/pyharp.git"  }
 vicivalve = { git = "https://gitlab.com/Poofjunior/vicivalve.git"}

--- a/src/brainwasher/brainslosher_models.py
+++ b/src/brainwasher/brainslosher_models.py
@@ -70,6 +70,7 @@ class BrainSlosherConfig(BaseModel, validate_assignment=True,):
     drain_volume_buffer_ml: float = Field(..., description="Buffer to add to draining volume to ensure chamber is completly empty.")
     fill_volume_ml: float = Field(..., description="Volume to fill chamber completly.")
     user_email: Optional[EmailStr] = Field(default=None, description="Optional email to send errors to.")    # validates email with email-validator package
+    instrument_name: Optional[str] = Field(default=None, description="Optional instrument name.") 
 
     @field_validator("selector_port_map")
     def check_required_keys(cls, v: dict[str, int]):

--- a/src/brainwasher/devices/instruments/brainslosher.py
+++ b/src/brainwasher/devices/instruments/brainslosher.py
@@ -6,7 +6,7 @@ from brainwasher.devices.vessels import ReactionVessel, WasteVessel
 from threading import RLock, current_thread, Lock
 from functools import wraps
 from datetime import datetime
-from typing import Literal, Union
+from typing import Literal, Union, Optional
 from pathlib import Path
 from time import perf_counter
 import yaml
@@ -34,7 +34,8 @@ class BrainSlosher(Instrument):
                 rxn_vessel: ReactionVessel,
                 pump: SY01B, 
                 mixer: PololuTicMixer, 
-                waste_vessel: WasteVessel):
+                waste_vessel: WasteVessel, 
+                job: Optional[BrainSlosherJob] = None):
         
         super().__init__()
 
@@ -59,8 +60,8 @@ class BrainSlosher(Instrument):
         self.job_status_lock = Lock()
         self.job_status: BrainSlosherJobStatus = BrainSlosherJobStatus(status="idle")
 
-        # attributes to calculate progress
-        self._job: BrainSlosherJob = None
+        # current job to run
+        self._job: BrainSlosherJob = job
 
         # track current step for progress
         self._step = 0

--- a/src/brainwasher/devices/instruments/brainslosher.py
+++ b/src/brainwasher/devices/instruments/brainslosher.py
@@ -5,7 +5,7 @@ from brainwasher.brainslosher_models import BrainSlosherConfig, BrainSlosherJob,
 from brainwasher.devices.vessels import ReactionVessel, WasteVessel
 from threading import RLock, current_thread, Lock
 from functools import wraps
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Literal, Union, Optional
 from pathlib import Path
 from time import perf_counter
@@ -281,7 +281,7 @@ class BrainSlosher(Instrument):
         self._step = 0 if not job.resume_state else job.resume_state.step
 
         try:
-            self.log.info("Job starting.")
+            self.log.info(f"Job starting. Job estimated finish at {timedelta(seconds=job.get_duration_s()) + datetime.now()}")
             with self.job_status_lock:
                 self.job_status = BrainSlosherJobStatus(status="running") 
             super()._run_job_worker(job, job_path)
@@ -318,7 +318,7 @@ class BrainSlosher(Instrument):
 
     def save_resume_state(self, job: BrainSlosherJob, resume_step: int, starting_solution: str, **kwargs):
         """
-            Save resume state of job. Overwrite since solution is string and startign solution is dict
+            Save resume state of job. Overwrite since solution is string and starting solution is dict
         """
         job.save_resume_state(resume_step, {starting_solution: self.config.fill_volume_ml*1000}, **kwargs)
 

--- a/src/brainwasher/devices/instruments/brainslosher.py
+++ b/src/brainwasher/devices/instruments/brainslosher.py
@@ -400,7 +400,7 @@ class BrainSlosher(Instrument):
   
         """
         # reset brainslosher 
-        self.reset_state()
+        self.clear_job()
         self.start_run(job)
 
     

--- a/src/brainwasher/devices/instruments/brainslosher.py
+++ b/src/brainwasher/devices/instruments/brainslosher.py
@@ -440,7 +440,6 @@ class BrainSlosher(Instrument):
         """
         Convienence method to get config
         """
-    
         return self.config.model_dump()
     
     def set_fill_volume(self, volume: float) -> None:

--- a/src/brainwasher/devices/instruments/brainslosher.py
+++ b/src/brainwasher/devices/instruments/brainslosher.py
@@ -45,15 +45,15 @@ class BrainSlosher(Instrument):
         self.waste = waste_vessel
         self.resume_state_overrides = {}
         
+        # Thread-safe protection within a class instance.
+        self.flowpath_lock = RLock()
+
         # need to reset pump every init
         self.pump.move_valve_to_position(self.config.selector_port_map["waste"])
         self.pump.reset_syringe_position()
 
         # drain chamber completley to put instrument in known state
         self.drain_chamber(self.config.fill_volume_ml)
-
-        # Thread-safe protection within a class instance.
-        self.flowpath_lock = RLock()
 
         # attribute to track events that occur in job_worker
         self.job_status_lock = Lock()

--- a/src/brainwasher/scripts/brainslosher_config.yaml
+++ b/src/brainwasher/scripts/brainslosher_config.yaml
@@ -53,6 +53,9 @@ logging:
             - console
             - file
             #- web_handler
+router_server_kwargs:
+    rpc_port: 5555
+    broadcast_port: 5556
 devices:
     selector_port_map:
         class: builtins.dict

--- a/src/brainwasher/scripts/brainslosher_main.py
+++ b/src/brainwasher/scripts/brainslosher_main.py
@@ -90,14 +90,14 @@ def main():
     config_name = args.config if not args.simulated else r"src\brainwasher\scripts\sim_brainslosher_config.yaml"
     config = Config(config_name)    # TODO: Should have some sort of validation here 
     
+    # setup logging
+    logging.config.dictConfig(dict(config.cfg["logging"]))  # set logging config before instantiating devices to not clear loggers
+
     # Create the instrument.
     device_specs = dict(config.cfg)
     factory = DeviceSpinner()
     device_trees = factory.create_devices_from_specs(device_specs["devices"])
     brainslosher = device_trees["brainwasher"]
-
-    # setup logging
-    logging.config.dictConfig(dict(config.cfg["logging"]))
     
     # set up formating for log server
     old_factory = logging.getLogRecordFactory()

--- a/src/brainwasher/scripts/brainslosher_main.py
+++ b/src/brainwasher/scripts/brainslosher_main.py
@@ -1,18 +1,14 @@
 from brainwasher.devices.instruments.brainslosher import BrainSlosher
-from brainwasher.brainslosher_models import BrainSlosherConfig, BrainSlosherJob
 from brainwasher.utils.email_issues import send_email
 import logging
 import logging.config
 from one_liner.server import RouterServer
-from pathlib import Path
 import time
-from datetime import datetime
-from typing import Literal
-import queue
 import argparse
 from device_spinner.config import Config
 from device_spinner.device_spinner import DeviceSpinner
-import yaml
+import os
+import brainwasher
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -96,6 +92,16 @@ def main():
     
     # setup logging
     logging.config.dictConfig(dict(config.cfg["logging"]))
+    
+    # set up formating for log server
+    old_factory = logging.getLogRecordFactory()
+    def record_factory(*args, **kwargs):
+        record = old_factory(*args, **kwargs)
+        record.project = "brainslosher"
+        record.version = brainwasher.__version__
+        record.comp_id = os.getenv("aibs_comp_id", "unknown")
+        return record
+    logging.setLogRecordFactory(record_factory)
         
     # Create the instrument.
     device_specs = dict(config.cfg)

--- a/src/brainwasher/scripts/brainslosher_main.py
+++ b/src/brainwasher/scripts/brainslosher_main.py
@@ -92,7 +92,7 @@ def main():
             handler.setLevel(args.log_level)
     
     config_name = args.config if not args.simulated else r"src\brainwasher\scripts\sim_brainslosher_config.yaml"
-    config = Config(config_name)
+    config = Config(config_name)    # TODO: Should have some sort of validation here 
     
     # setup logging
     logging.config.dictConfig(dict(config.cfg["logging"]))
@@ -102,7 +102,7 @@ def main():
     factory = DeviceSpinner()
     device_trees = factory.create_devices_from_specs(device_specs["devices"])
     brainslosher = device_trees["brainwasher"]
-    server = ZMQServer(instances={"brainslosher":brainslosher})
+    server = ZMQServer(instances={"brainslosher":brainslosher}, **config.cfg.get("router_server_kwargs", {}))
     server.run()
 
     while not server.context.closed:

--- a/src/brainwasher/scripts/brainslosher_main.py
+++ b/src/brainwasher/scripts/brainslosher_main.py
@@ -90,6 +90,12 @@ def main():
     config_name = args.config if not args.simulated else r"src\brainwasher\scripts\sim_brainslosher_config.yaml"
     config = Config(config_name)    # TODO: Should have some sort of validation here 
     
+    # Create the instrument.
+    device_specs = dict(config.cfg)
+    factory = DeviceSpinner()
+    device_trees = factory.create_devices_from_specs(device_specs["devices"])
+    brainslosher = device_trees["brainwasher"]
+
     # setup logging
     logging.config.dictConfig(dict(config.cfg["logging"]))
     
@@ -100,14 +106,14 @@ def main():
         record.project = "brainslosher"
         record.version = brainwasher.__version__
         record.comp_id = os.getenv("aibs_comp_id", "unknown")
+        
+        # set message prefix for log server readability
+        prefix = f"{brainslosher.config.instrument_name}: " if brainslosher.config.instrument_name else ""
+        record.msg = f"{prefix}{record.msg}"
         return record
     logging.setLogRecordFactory(record_factory)
-        
-    # Create the instrument.
-    device_specs = dict(config.cfg)
-    factory = DeviceSpinner()
-    device_trees = factory.create_devices_from_specs(device_specs["devices"])
-    brainslosher = device_trees["brainwasher"]
+
+    # start server
     server = ZMQServer(instances={"brainslosher":brainslosher}, **config.cfg.get("router_server_kwargs", {}))
     server.run()
 

--- a/src/brainwasher/scripts/sim_brainslosher_config.yaml
+++ b/src/brainwasher/scripts/sim_brainslosher_config.yaml
@@ -1,4 +1,3 @@
-
 logging:
     version: 1
     disable_existing_loggers: true

--- a/src/brainwasher/scripts/sim_brainslosher_config.yaml
+++ b/src/brainwasher/scripts/sim_brainslosher_config.yaml
@@ -66,6 +66,7 @@ devices:
             diH20: 2
         drain_volume_buffer_ml: .5
         fill_volume_ml: 10 
+        instrument_name: Simulated Brainslosher
     rxn_vessel:
         class: brainwasher.devices.vessels.ReactionVessel
         skip_kwds: [name]

--- a/src/brainwasher/scripts/sim_brainslosher_config.yaml
+++ b/src/brainwasher/scripts/sim_brainslosher_config.yaml
@@ -51,7 +51,7 @@ logging:
             handlers:
             - console
             - file
-            #- web_handler
+            - web_handler
 devices:
     config: 
       class: brainwasher.brainslosher_models.BrainSlosherConfig

--- a/uv.lock
+++ b/uv.lock
@@ -78,7 +78,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 brainslosher-group = [
     { name = "email-validator", specifier = ">=2.3.0" },
-    { name = "one-liner", git = "ssh://git@github.com/AllenNeuralDynamics/one-liner.git" },
+    { name = "one-liner", git = "ssh://git@github.com/AllenNeuralDynamics/one-liner.git?branch=main" },
     { name = "ticlib" },
 ]
 brainwasher-group = [
@@ -431,8 +431,8 @@ wheels = [
 
 [[package]]
 name = "one-liner"
-version = "0.1.1.dev1"
-source = { git = "ssh://git@github.com/AllenNeuralDynamics/one-liner.git#1d3e7592b150f3eaf7fd7276097e70072de830c9" }
+version = "0.1.1.dev2"
+source = { git = "ssh://git@github.com/AllenNeuralDynamics/one-liner.git?branch=main#22aa37370c3678726ebacb2f0a2e8ae263a94704" }
 dependencies = [
     { name = "orjson" },
     { name = "pydantic" },


### PR DESCRIPTION
Adds name to instrument config. This will be used by ui to display name on header to differentiate multiple instances of instruments on one computer. Also add a job arg in the init for the ability to have a default job set up, passes in kwargs for router server, and configures logs for log server